### PR TITLE
Downgrade Django to 2.0.8 to workaround render argument issue

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ django-dotenv==1.4.1
 django-embed-video==1.1.2
 django-grappelli==2.10.1
 django-solo==1.1.3
-Django==2.1.5
+Django==2.0.8
 gunicorn==19.7.1
 psycopg2==2.7.7
 social-auth-app-django==2.1.0


### PR DESCRIPTION
https://stackoverflow.com/questions/52039654/django-typeerror-render-got-an-unexpected-keyword-argument-renderer