### PR TITLE
Add command to switch translations for given user and song

### DIFF
--- a/thiamsu/management/commands/switch.py
+++ b/thiamsu/management/commands/switch.py
@@ -1,0 +1,88 @@
+from django.core.management.base import BaseCommand
+from django.db import models
+
+from thiamsu.models.translation import Translation
+
+
+class Command(BaseCommand):
+    help = "Load ptt data from csv file"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--user-id", default=None, help="Target user to switch translations"
+        )
+        parser.add_argument(
+            "--song-id", default=None, help="Target song to switch translations"
+        )
+        parser.add_argument("--dryrun", action="store_true")
+
+    def get_latest_translations(self, lang, user_id=None, song_id=None):
+        """
+        Return map {(song_id, line_no): latest_translation} of given contributor and language
+        """
+        q_statement = models.Q(lang__exact=lang)
+        if user_id:
+            q_statement &= models.Q(contributor__exact=user_id)
+        if song_id:
+            q_statement &= models.Q(song__exact=song_id)
+
+        translations = Translation.objects.filter(q_statement).all()
+
+        latest_translations = {}
+        for t in translations:
+            k = (t.song.id, t.line_no)
+            curr = latest_translations.get(k)
+            if not curr or curr.created_at < t.created_at:
+                latest_translations[k] = t
+        return latest_translations
+
+    def handle(self, *args, **options):
+        hanzi_translations = self.get_latest_translations(
+            lang="hanzi", user_id=options["user_id"], song_id=options["song_id"]
+        )
+        tailo_translations = self.get_latest_translations(
+            lang="tailo", user_id=options["user_id"], song_id=options["song_id"]
+        )
+
+        for song_id, line_no in sorted(hanzi_translations.keys()):
+            k = (song_id, line_no)
+            song = hanzi_translations[k].song
+            contributor = hanzi_translations[k].contributor
+            if k not in tailo_translations:
+                continue
+            if options["dryrun"]:
+                print(
+                    "switch",
+                    song.id,
+                    line_no,
+                    hanzi_translations[k].content,
+                    tailo_translations[k].content,
+                    "(dryrun)",
+                )
+            else:
+                # save hanzi as new tailo
+                Translation(
+                    song=song,
+                    line_no=line_no,
+                    lang="tailo",
+                    content=hanzi_translations[k].content,
+                    contributor=contributor,
+                ).save()
+
+                # save tailo as new hanzi
+                Translation(
+                    song=song,
+                    line_no=line_no,
+                    lang="hanzi",
+                    content=tailo_translations[k].content,
+                    contributor=contributor,
+                ).save()
+
+                # log
+                print(
+                    "switch",
+                    song.id,
+                    line_no,
+                    hanzi_translations[k].content,
+                    tailo_translations[k].content,
+                )


### PR DESCRIPTION
因為有個使用者覺得歌詞的排列順序改成「原文、漢字、台羅」比較好，但之前系統的設計並不是這樣，所以他就把台羅歌詞填在漢字的欄位，漢字歌詞填在台羅的欄位。

因為該名使用者送了三百多首歌、八千多句歌詞，是個大戶，所以這個 command 是為了修正資料，幫他把歌詞對調回來。

這邊忘記考慮如果後來又有人把歌詞修正的情況，導致該句歌詞又會被程式蓋回來，但數量應該不多，就先這樣。